### PR TITLE
Disable keep alive behavior on manual socket close

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -75,6 +75,8 @@ class Connection extends EventEmitter {
   }
 
   end() {
+    clearInterval(this._keepAlive);
+
     this._socket.end();
   }
 


### PR DESCRIPTION
(Before starting I'd like to thank you for your package, it's been useful to me :)

Keep alive behavior (involving heartbeat checks) is correctly being disabled when the socket ends, but the same doesn't happen when the socket is ended manually.

Since Node.js net sockets don't emit an "end" event when ended manually; we have to disable the keep alive behavior on manual socket end calls.